### PR TITLE
Add types analyzer (#41)

### DIFF
--- a/Sources/SwiftInspectorCommands/InspectorCommand.swift
+++ b/Sources/SwiftInspectorCommands/InspectorCommand.swift
@@ -35,6 +35,7 @@ public struct InspectorCommand: ParsableCommand {
       InitializerCommand.self,
       StaticUsageCommand.self,
       TypealiasCommand.self,
+      TypesCommand.self,
       TypeConformanceCommand.self,
       TypeLocationCommand.self,
   ])

--- a/Sources/SwiftInspectorCommands/Tests/TypesCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypesCommandSpec.swift
@@ -1,0 +1,125 @@
+// Created by Tyler Hedrick on 8/13/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class TypesCommandSpec: QuickSpec {
+  override func spec() {
+    var fileURL: URL!
+
+    afterEach {
+      guard let fileURL = fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+
+    describe("run") {
+      context("with no arguments") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["types"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when path is invalid") {
+        it("fails when empty") {
+          let result = try? TestTypesCommandTask.run(path: "")
+          expect(result?.didFail) == true
+        }
+
+        it("fails when it doesn't exist") {
+          let result = try? TestTypesCommandTask.run(path: "/fake/path")
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when path is valid file") {
+        it("succeeds") {
+          fileURL = try? Temporary.makeFile(content: "struct Foo { }")
+          let path = fileURL?.path ?? ""
+          let result = try? TestTypesCommandTask.run(path: path)
+          expect(result?.didSucceed) == true
+        }
+
+        it("runs and outputs the result without comment") {
+          fileURL = try? Temporary.makeFile(content: """
+                                                   // This is a comment
+                                                   struct Foo { }
+                                                   """)
+          let path = fileURL?.path ?? ""
+          let result = try? TestTypesCommandTask.run(path: path)
+          expect(result?.outputMessage).to(contain("Foo,struct"))
+        }
+      }
+
+      context("when path is a folder") {
+        var folderURL: URL!
+        beforeEach {
+          folderURL = try! Temporary.makeFolder()
+        }
+        afterEach {
+          try! Temporary.removeItem(at: folderURL)
+        }
+
+        it("succeeds") {
+          let result = try? TestTypesCommandTask.run(path: folderURL.path)
+
+          expect(result?.didSucceed) == true
+        }
+
+        it("outputs the correct types") {
+          let _ = try? Temporary.makeFile(
+            content: """
+                     class Foo { }
+                     """,
+            atPath: folderURL.path)
+
+          let _ = try? Temporary.makeFile(
+          content: """
+                   class Bar { }
+                   """,
+          atPath: folderURL.path)
+
+          let result = try? TestTypesCommandTask.run(path: folderURL.path)
+          let outputMessageLines = result?.outputMessage?.split { $0.isNewline }
+          expect(outputMessageLines).to(contain(["Foo,class", "Bar,class"]))
+        }
+      }
+
+    }
+  }
+}
+
+private struct TestTypesCommandTask {
+  fileprivate static func run(path: String, arguments: [String] = []) throws -> TaskStatus {
+    let arguments = ["types", "--path", path] + arguments
+    return try TestTask.run(withArguments: arguments)
+  }
+}

--- a/Sources/SwiftInspectorCommands/TypesCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypesCommand.swift
@@ -1,0 +1,69 @@
+// Created by Tyler Hedrick on 8/12/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import ArgumentParser
+import Foundation
+import SwiftInspectorCore
+
+final class TypesCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "types",
+    abstract: "Finds information about types in a file"
+  )
+
+  @Option(help: "The absolute path to the file or directory to inspect")
+  var path: String
+
+  /// Runs the command
+  func run() throws {
+    let cachedSyntaxTree = CachedSyntaxTree()
+    let analyzer = TypesAnalyzer(cachedSyntaxTree: cachedSyntaxTree)
+    let fileURL = URL(fileURLWithPath: path)
+    let outputArray = try FileManager.default.swiftFiles(at: fileURL)
+      .reduce(Set<String>()) { result, url in
+        let statements = try analyzer.analyze(fileURL: url)
+        let output = statements.map { outputString(from: $0) }
+        return result.union(output)
+    }
+
+    let output = outputArray.filter { !$0.isEmpty }.joined(separator: "\n")
+    print(output)
+  }
+
+  /// Validates if the arguments of this command are valid
+  func validate() throws {
+    guard !path.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--path")
+    }
+
+    let pathURL = URL(fileURLWithPath: path)
+    guard FileManager.default.isSwiftFile(at: pathURL) || pathURL.hasDirectoryPath else {
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
+    }
+  }
+
+  private func outputString(from info: TypeInfo) -> String {
+    "\(info.name),\(info.type)"
+  }
+}

--- a/Sources/SwiftInspectorCore/Tests/TypesAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypesAnalyzerSpec.swift
@@ -1,0 +1,388 @@
+// Created by Tyler Hedrick 8/13/20.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+
+@testable import SwiftInspectorCore
+
+final class TypesAnalyzerSpec: QuickSpec {
+
+  override func spec() {
+    var fileURL: URL!
+    var sut: TypesAnalyzer!
+
+    beforeEach {
+      sut = TypesAnalyzer()
+    }
+
+    afterEach {
+      guard let fileURL = fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("analyze(fileURL:)") {
+      context("there are no types present") {
+        beforeEach {
+          let content =
+          """
+          import Foundation
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("returns empty array") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result).to(beEmpty())
+        }
+      }
+
+      context("struct is present") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          struct Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .struct
+        }
+        it("has empty comments") {
+          expect(result?[0].comment.isEmpty) == true
+        }
+      }
+
+      context("enum is present") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          enum Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .enum
+        }
+        it("has empty comments") {
+          expect(result?[0].comment.isEmpty) == true
+        }
+      }
+
+      context("class is present") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          class Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .class
+        }
+        it("has empty comments") {
+          expect(result?[0].comment.isEmpty) == true
+        }
+      }
+
+      context("protocol is present") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .protocol
+        }
+        it("has empty comments") {
+          expect(result?[0].comment.isEmpty) == true
+        }
+      }
+
+      context("struct is present with comment") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          struct Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .struct
+        }
+        it("returns comments associated with the type") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+      }
+
+      context("enum is present with comment") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          enum Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .enum
+        }
+        it("returns comments associated with the type") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+      }
+
+      context("class is present with comment") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          class Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .class
+        }
+        it("returns comments associated with the type") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+      }
+
+      context("protocol is present with comment") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the type's Type") {
+          expect(result?[0].type) == .protocol
+        }
+        it("returns comments associated with the type") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+      }
+
+      context("multiple types present") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          protocol Foo { }
+
+          // This is a different comment
+          private final class Bar: Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("has a non-empty result") {
+          expect(result).notTo(beEmpty())
+        }
+        it("returns the first type's name") {
+          expect(result?[0].name) == "Foo"
+        }
+        it("returns the first type's Type") {
+          expect(result?[0].type) == .protocol
+        }
+        it("returns the comments associated with the first type") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+
+        it("returns the second type's name") {
+          expect(result?[1].name) == "Bar"
+        }
+        it("returns the second type's Type") {
+          expect(result?[1].type) == .class
+        }
+        it("returns the comments associated with the second type") {
+          expect(result?[1].comment).to(contain("// This is a different comment"))
+        }
+      }
+
+      context("line comments") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          // This is a comment
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("contains the comment") {
+          expect(result?[0].comment).to(contain("// This is a comment"))
+        }
+      }
+
+      context("block comments") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          /* This is a comment */
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("contains the comment") {
+          expect(result?[0].comment).to(contain("/* This is a comment */"))
+        }
+      }
+
+      context("doc line comments") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          /// This is a comment
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("contains the comment") {
+          expect(result?[0].comment).to(contain("/// This is a comment"))
+        }
+      }
+
+      context("doc block comments") {
+        var result: [TypeInfo]?
+
+        beforeEach {
+          let content =
+          """
+          /** This is a comment */
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+          result = try? sut.analyze(fileURL: fileURL)
+        }
+
+        it("contains the comment") {
+          expect(result?[0].comment).to(contain("/** This is a comment */"))
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/SwiftInspectorCore/TypesAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypesAnalyzer.swift
@@ -1,0 +1,124 @@
+// Created by Tyler Hedrick on 8/12/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+import Foundation
+import SwiftSyntax
+
+public final class TypesAnalyzer: Analyzer {
+
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  /// Analyzes the types located in the provided file
+  /// - Parameter fileURL: The fileURL where the Swift file is located
+  public func analyze(fileURL: URL) throws -> [TypeInfo] {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    var result = [TypeInfo]()
+    let visitor = TypeInfoSyntaxVisitor() { typeInfo in
+      result.append(typeInfo)
+    }
+    visitor.walk(syntax)
+    return result
+  }
+
+  // MARK: Private
+
+  private let cachedSyntaxTree: CachedSyntaxTree
+}
+
+private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
+  init(_ onNodeVisit: @escaping (TypeInfo) -> Void) {
+    self.onNodeVisit = onNodeVisit
+  }
+
+  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    onNodeVisit(.init(
+      type: .class,
+      name: node.identifier.text,
+      comment: comment(from: node.leadingTrivia)))
+    return .visitChildren
+  }
+
+  override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    onNodeVisit(.init(
+      type: .enum,
+      name: node.identifier.text,
+      comment: comment(from: node.leadingTrivia)))
+    return .visitChildren
+  }
+
+  override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    onNodeVisit(.init(
+      type: .protocol,
+      name: node.identifier.text,
+      comment: comment(from: node.leadingTrivia)))
+    return .visitChildren
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    onNodeVisit(.init(
+      type: .struct,
+      name: node.identifier.text,
+      comment: comment(from: node.leadingTrivia)))
+    return .visitChildren
+  }
+
+  // MARK: Private
+
+  private let onNodeVisit: (TypeInfo) -> Void
+
+  private func comment(from trivia: Trivia?) -> String {
+    guard let trivia = trivia else { return "" }
+    return trivia.compactMap { piece -> String? in
+      switch piece {
+      case .lineComment(let str): return str
+      case .blockComment(let str): return str
+      case .docLineComment(let str): return str
+      case .docBlockComment(let str): return str
+      default: return nil
+      }
+    }.joined(separator: "\n")
+  }
+}
+
+// MARK: TypeInfo
+
+public struct TypeInfo {
+  public enum SwiftType: String {
+    case `class`
+    case `struct`
+    case `protocol`
+    case `enum`
+  }
+
+  /// Swift type name (class, struct, protocol, or enum)
+  public let type: SwiftType
+  /// The name of the type
+  public let name: String
+  /// Comments associated with this type (leadingTrivia from SwiftSyntax)
+  public let comment: String
+}


### PR DESCRIPTION
* Add types analyzer for a file

* tests

* add more tests for TypesCommand

* address comments and support directories

* remove comments from Command

* Update Sources/SwiftInspectorCommands/Tests/TypesCommandSpec.swift

Co-authored-by: Francisco Diaz <fdiaz@users.noreply.github.com>

Co-authored-by: Francisco Diaz <fdiaz@users.noreply.github.com>